### PR TITLE
valU JOD currency

### DIFF
--- a/includes/paytabs_core.php
+++ b/includes/paytabs_core.php
@@ -1511,7 +1511,7 @@ class PaytabsApi
         '11' => [
             'name' => 'valu',
             'title' => 'PayTabs - valU',
-            'currencies' => ['EGP'],
+            'currencies' => ['EGP','JOD'],
             'groups' => [
                 PaytabsApi::GROUP_IFRAME,
                 PaytabsApi::GROUP_REFUND

--- a/includes/paytabs_core.php
+++ b/includes/paytabs_core.php
@@ -2,11 +2,11 @@
 
 /**
  * PayTabs v2 PHP SDK
- * Version: 2.30.0
+ * Version: 2.30.1
  * PHP >= 7.0.0
  */
 
-define('PAYTABS_SDK_VERSION', '2.30.0');
+define('PAYTABS_SDK_VERSION', '2.30.1');
 
 define('PAYTABS_DEBUG_FILE_NAME', 'debug_paytabs.log');
 define('PAYTABS_DEBUG_SEVERITY', ['Info', 'Warning', 'Error']);
@@ -1511,7 +1511,7 @@ class PaytabsApi
         '11' => [
             'name' => 'valu',
             'title' => 'PayTabs - valU',
-            'currencies' => ['EGP','JOD'],
+            'currencies' => ['EGP', 'JOD'],
             'groups' => [
                 PaytabsApi::GROUP_IFRAME,
                 PaytabsApi::GROUP_REFUND

--- a/paytabs-woocommerce.php
+++ b/paytabs-woocommerce.php
@@ -9,7 +9,7 @@
  * Plugin URI:    https://paytabs.com/
  * Description:   PayTabs is a <strong>3rd party payment gateway</strong>. Ideal payment solutions for your internet business.
 
- * Version:       5.10.0
+ * Version:       5.10.1
  * Requires PHP:  7.0
  * Requires Plugins: woocommerce
 
@@ -24,7 +24,7 @@ if (!function_exists('add_action')) {
 }
 
 
-define('PAYTABS_PAYPAGE_VERSION', '5.10.0');
+define('PAYTABS_PAYPAGE_VERSION', '5.10.1');
 define('PAYTABS_PAYPAGE_DIR', plugin_dir_path(__FILE__));
 define('PAYTABS_PAYPAGE_URL', plugins_url("/", __FILE__));
 define('PAYTABS_PAYPAGE_ICONS_URL', plugins_url("icons/", __FILE__));


### PR DESCRIPTION


## **Pull Request Description**

### **Business Need**
This update introduces support for the **Jordanian Dinar (JOD)** currency within the **Valu** payment method.  
As Valu expands its services to Jordan, this enhancement enables merchants to process Valu transactions in JOD seamlessly through the WooCommerce integration.

---

### **Summary of Changes**

A new release (**v5.10.1**) has been prepared to include the following updates:

#### **1. Extending Valu Currency Support**
Added **JOD** to the list of supported currencies for the Valu payment method inside `includes/paytabs_core.php`:

```php
'11' => [
    'name' => 'valu',
    'title' => 'PayTabs - valU',
    'currencies' => ['EGP','JOD'],
],
```

---

#### **2. Version Upgrade**
Updated plugin version and constants in `paytabs-woocommerce.php`:

```php
 * Version:       5.10.1
...
define('PAYTABS_PAYPAGE_VERSION', '5.10.1');
```

---

### **Compatibility Notes**
- No breaking changes introduced.  
- Merchants using Valu with JOD will see the payment method in the admin payment options.  
- Existing Valu transactions and configurations remain unaffected.
